### PR TITLE
Default scope url support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Client credential provider is used by services and desktop applications to acqui
 This provider leverages on [MSALs Client Credential Flows](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Client-credential-flows) to authenticate Microsoft Graph requests.
 
 ```csharp
-IConfidentialClientApplication clientApplication = ClientCredentialProvider.CreateClientApplication(clientId, redirectUri, clientCredential);
+IConfidentialClientApplication clientApplication = ClientCredentialProvider.CreateClientApplication(clientId, clientCredential);
 
 ClientCredentialProvider authenticationProvider = new ClientCredentialProvider(clientApplication);
 ```

--- a/src/Microsoft.Graph.Auth.Test/ConfidentialClient/AuthorizationCodeProviderTests.cs
+++ b/src/Microsoft.Graph.Auth.Test/ConfidentialClient/AuthorizationCodeProviderTests.cs
@@ -78,6 +78,25 @@
         }
 
         [TestMethod]
+        public void AuthorizationCodeProvider_ShouldUseDefaultScopeUrlWhenScopeIsNull()
+        {
+            AuthorizationCodeProvider authCodeFlowProvider = new AuthorizationCodeProvider(_mockClientApplicationBase.Object);
+
+            Assert.IsNotNull(authCodeFlowProvider.Scopes, "Default scope url not set.");
+            Assert.IsTrue(authCodeFlowProvider.Scopes.Count().Equals(1), "Unexpected number of scopes set.");
+            Assert.AreEqual(AuthConstants.DefaultScopeUrl, authCodeFlowProvider.Scopes.FirstOrDefault(), "Unexpected scope set.");
+        }
+
+        [TestMethod]
+        public void AuthorizationCodeProvider_ShouldThrowExceptionWhenScopesAreEmpty()
+        {
+            AuthenticationException ex = Assert.ThrowsException<AuthenticationException>(() => new AuthorizationCodeProvider(_mockClientApplicationBase.Object, new string[] { }));
+
+            Assert.AreEqual(ex.Error.Message, ErrorConstants.Message.EmptyScopes, "Invalid exception message.");
+            Assert.AreEqual(ex.Error.Code, ErrorConstants.Codes.InvalidRequest, "Invalid exception code.");
+        }
+
+        [TestMethod]
         public async Task AuthorizationCodeProvider_ShouldThrowChallangeRequiredExceptionWhenNoUserAccountIsNull()
         {
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");

--- a/src/Microsoft.Graph.Auth.Test/ConfidentialClient/ClientCredentialProviderTests.cs
+++ b/src/Microsoft.Graph.Auth.Test/ConfidentialClient/ClientCredentialProviderTests.cs
@@ -71,6 +71,16 @@ namespace Microsoft.Graph.Auth.Test.ConfidentialClient
         }
 
         [TestMethod]
+        public void ClientCredentialProvider_ShouldUseDefaultScopeUrlWhenScopeIsNull()
+        {
+            ClientCredentialProvider clientCredentialProvider = new ClientCredentialProvider(_mockClientApplicationBase.Object);
+
+            Assert.IsNotNull(clientCredentialProvider.Scopes, "Default scope url not set.");
+            Assert.IsTrue(clientCredentialProvider.Scopes.Count().Equals(1), "Unexpected number of scopes set.");
+            Assert.AreEqual(AuthConstants.DefaultScopeUrl, clientCredentialProvider.Scopes.FirstOrDefault(), "Unexpected scope set.");
+        }
+
+        [TestMethod]
         public async Task ClientCredentialProvider_ShouldGetNewAccessTokenWhenUserAccountIsNull()
         {
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");

--- a/src/Microsoft.Graph.Auth.Test/ConfidentialClient/OnBehalfOfProviderTests.cs
+++ b/src/Microsoft.Graph.Auth.Test/ConfidentialClient/OnBehalfOfProviderTests.cs
@@ -80,6 +80,25 @@
         }
 
         [TestMethod]
+        public void OnBehalfOfProvider_ShouldUseDefaultScopeUrlWhenScopeIsNull()
+        {
+            OnBehalfOfProvider onBehalfOfProvider = new OnBehalfOfProvider(_mockClientApplicationBase.Object, null);
+
+            Assert.IsNotNull(onBehalfOfProvider.Scopes, "Default scope url not set.");
+            Assert.IsTrue(onBehalfOfProvider.Scopes.Count().Equals(1), "Unexpected number of scopes set.");
+            Assert.AreEqual(AuthConstants.DefaultScopeUrl, onBehalfOfProvider.Scopes.FirstOrDefault(), "Unexpected scope set.");
+        }
+
+        [TestMethod]
+        public void OnBehalfOfProvider_ShouldThrowExceptionWhenScopesAreEmpty()
+        {
+            AuthenticationException ex = Assert.ThrowsException<AuthenticationException>(() => new OnBehalfOfProvider(_mockClientApplicationBase.Object, new string[] { }));
+
+            Assert.AreEqual(ex.Error.Message, ErrorConstants.Message.EmptyScopes, "Invalid exception message.");
+            Assert.AreEqual(ex.Error.Code, ErrorConstants.Codes.InvalidRequest, "Invalid exception code.");
+        }
+
+        [TestMethod]
         public async Task OnBehalfOfProvider_ShouldGetNewAccessTokenWithNoUserAssertion()
         {
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");

--- a/src/Microsoft.Graph.Auth.Test/PublicClient/DeviceCodeProviderTests.cs
+++ b/src/Microsoft.Graph.Auth.Test/PublicClient/DeviceCodeProviderTests.cs
@@ -77,6 +77,25 @@
         }
 
         [TestMethod]
+        public void DeviceCodeProvider_ShouldUseDefaultScopeUrlWhenScopeIsNull()
+        {
+            DeviceCodeProvider deviceCodeProvider = new DeviceCodeProvider(_mockClientApplicationBase.Object, null);
+
+            Assert.IsNotNull(deviceCodeProvider.Scopes, "Default scope url not set.");
+            Assert.IsTrue(deviceCodeProvider.Scopes.Count().Equals(1), "Unexpected number of scopes set.");
+            Assert.AreEqual(AuthConstants.DefaultScopeUrl, deviceCodeProvider.Scopes.FirstOrDefault(), "Unexpected scope set.");
+        }
+
+        [TestMethod]
+        public void DeviceCodeProvider_ShouldThrowExceptionWhenScopesAreEmpty()
+        {
+            AuthenticationException ex = Assert.ThrowsException<AuthenticationException>(() => new DeviceCodeProvider(_mockClientApplicationBase.Object, new string[] { }));
+
+            Assert.AreEqual(ex.Error.Message, ErrorConstants.Message.EmptyScopes, "Invalid exception message.");
+            Assert.AreEqual(ex.Error.Code, ErrorConstants.Codes.InvalidRequest, "Invalid exception code.");
+        }
+
+        [TestMethod]
         public async Task DeviceCodeProvider_ShouldGetNewAccessTokenWithNoIAccount()
         {
             UserAssertion assertion = new UserAssertion("access_token");

--- a/src/Microsoft.Graph.Auth.Test/PublicClient/IntegratedWindowsAuthenticationProviderTests.cs
+++ b/src/Microsoft.Graph.Auth.Test/PublicClient/IntegratedWindowsAuthenticationProviderTests.cs
@@ -76,6 +76,25 @@
         }
 
         [TestMethod]
+        public void IntegratedWindows_ShouldUseDefaultScopeUrlWhenScopeIsNull()
+        {
+            IntegratedWindowsAuthenticationProvider authProvider = new IntegratedWindowsAuthenticationProvider(_mockClientApplicationBase.Object, null);
+
+            Assert.IsNotNull(authProvider.Scopes, "Default scope url not set.");
+            Assert.IsTrue(authProvider.Scopes.Count().Equals(1), "Unexpected number of scopes set.");
+            Assert.AreEqual(AuthConstants.DefaultScopeUrl, authProvider.Scopes.FirstOrDefault(), "Unexpected scope set.");
+        }
+
+        [TestMethod]
+        public void IntegratedWindows_ShouldThrowExceptionWhenScopesAreEmpty()
+        {
+            AuthenticationException ex = Assert.ThrowsException<AuthenticationException>(() => new IntegratedWindowsAuthenticationProvider(_mockClientApplicationBase.Object, new string[] { }));
+
+            Assert.AreEqual(ex.Error.Message, ErrorConstants.Message.EmptyScopes, "Invalid exception message.");
+            Assert.AreEqual(ex.Error.Code, ErrorConstants.Codes.InvalidRequest, "Invalid exception code.");
+        }
+
+        [TestMethod]
         public async Task IntegratedWindows_ShouldGetNewAccessTokenWithNoIAccount()
         {
             UserAssertion assertion = new UserAssertion("access_token");

--- a/src/Microsoft.Graph.Auth.Test/PublicClient/InteractiveAuthenticationProviderTests.cs
+++ b/src/Microsoft.Graph.Auth.Test/PublicClient/InteractiveAuthenticationProviderTests.cs
@@ -76,6 +76,26 @@
         }
 
         [TestMethod]
+        public void InteractiveAuthProvider_ShouldUseDefaultScopeUrlWhenScopeIsNull()
+        {
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            InteractiveAuthenticationProvider authProvider = new InteractiveAuthenticationProvider(_mockClientApplicationBase.Object, null);
+
+            Assert.IsNotNull(authProvider.Scopes, "Default scope url not set.");
+            Assert.IsTrue(authProvider.Scopes.Count().Equals(1), "Unexpected number of scopes set.");
+            Assert.AreEqual(AuthConstants.DefaultScopeUrl, authProvider.Scopes.FirstOrDefault(), "Unexpected scope set.");
+        }
+
+        [TestMethod]
+        public void InteractiveAuthProvider_ShouldThrowExceptionWhenScopesAreEmpty()
+        {
+            AuthenticationException ex = Assert.ThrowsException<AuthenticationException>(() => new InteractiveAuthenticationProvider(_mockClientApplicationBase.Object, new string[] { }));
+
+            Assert.AreEqual(ex.Error.Message, ErrorConstants.Message.EmptyScopes, "Invalid exception message.");
+            Assert.AreEqual(ex.Error.Code, ErrorConstants.Codes.InvalidRequest, "Invalid exception code.");
+        }
+
+        [TestMethod]
         public async Task InteractiveAuthProvider_ShouldGetNewAccessTokenWithNoIAccount()
         {
             UserAssertion assertion = new UserAssertion("access_token");

--- a/src/Microsoft.Graph.Auth.Test/PublicClient/UsernamePasswordProviderTests.cs
+++ b/src/Microsoft.Graph.Auth.Test/PublicClient/UsernamePasswordProviderTests.cs
@@ -77,6 +77,26 @@
         }
 
         [TestMethod]
+        public void UsernamePasswordProvider_ShouldUseDefaultScopeUrlWhenScopeIsNull()
+        {
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.org/foo");
+            UsernamePasswordProvider authProvider = new UsernamePasswordProvider(_mockClientApplicationBase.Object, null);
+
+            Assert.IsNotNull(authProvider.Scopes, "Default scope url not set.");
+            Assert.IsTrue(authProvider.Scopes.Count().Equals(1), "Unexpected number of scopes set.");
+            Assert.AreEqual(AuthConstants.DefaultScopeUrl, authProvider.Scopes.FirstOrDefault(), "Unexpected scope set.");
+        }
+
+        [TestMethod]
+        public void UsernamePasswordProvider_ShouldThrowExceptionWhenScopesAreEmpty()
+        {
+            AuthenticationException ex = Assert.ThrowsException<AuthenticationException>(() => new UsernamePasswordProvider(_mockClientApplicationBase.Object, new string[] { }));
+
+            Assert.AreEqual(ex.Error.Message, ErrorConstants.Message.EmptyScopes, "Invalid exception message.");
+            Assert.AreEqual(ex.Error.Code, ErrorConstants.Codes.InvalidRequest, "Invalid exception code.");
+        }
+
+        [TestMethod]
         public async Task UsernamePasswordProvider_ShouldGetNewAccessTokenWithNoIAccount()
         {
             UserAssertion assertion = new UserAssertion("access_token");

--- a/src/Microsoft.Graph.Auth/AuthConstants.cs
+++ b/src/Microsoft.Graph.Auth/AuthConstants.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Graph.Auth
     using System.Collections.Generic;
     internal static class AuthConstants
     {
+        internal const string DefaultScopeUrl = "https://graph.microsoft.com/.default";
         internal static class Tenants
         {
             public const string Common = "common";

--- a/src/Microsoft.Graph.Auth/ConfidentialClient/AuthorizationCodeProvider.cs
+++ b/src/Microsoft.Graph.Auth/ConfidentialClient/AuthorizationCodeProvider.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Graph.Auth
         /// Construct a new <see cref="AuthorizationCodeProvider"/>
         /// </summary>
         /// <param name="confidentialClientApplication"><see cref="IConfidentialClientApplication"/> used to authentication requests.</param>
-        /// <param name="scopes">Scopes required to access Microsoft Graph.</param>
+        /// <param name="scopes">Scopes required to access Microsoft Graph. This defaults to https://graph.microsoft.com/.default if none is set.</param>
         public AuthorizationCodeProvider(
             IConfidentialClientApplication confidentialClientApplication,
-            string[] scopes)
+            string[] scopes = null)
             : base(scopes)
         {
             ClientApplication = confidentialClientApplication ?? throw new AuthenticationException(

--- a/src/Microsoft.Graph.Auth/ConfidentialClient/ClientCredentialProvider.cs
+++ b/src/Microsoft.Graph.Auth/ConfidentialClient/ClientCredentialProvider.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Graph.Auth
     /// </summary>
     public class ClientCredentialProvider : MsalAuthenticationBase, IAuthenticationProvider
     {
-        private const string _resourceUrl = "https://graph.microsoft.com/.default";
-
         /// <summary>
         /// Constructs a new <see cref=" ClientCredentialProvider"/>
         /// </summary>
@@ -66,7 +64,7 @@ namespace Microsoft.Graph.Auth
             {
                 try
                 {
-                    AuthenticationResult authenticationResult = await (ClientApplication as IConfidentialClientApplication).AcquireTokenForClientAsync(new string[] { _resourceUrl }, msalAuthProviderOption.ForceRefresh);
+                    AuthenticationResult authenticationResult = await (ClientApplication as IConfidentialClientApplication).AcquireTokenForClientAsync(new string[] { AuthConstants.DefaultScopeUrl }, msalAuthProviderOption.ForceRefresh);
 
                     if (!string.IsNullOrEmpty(authenticationResult?.AccessToken))
                         httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue(CoreConstants.Headers.Bearer, authenticationResult.AccessToken);

--- a/src/Microsoft.Graph.Auth/ConfidentialClient/OnBehalfOfProvider.cs
+++ b/src/Microsoft.Graph.Auth/ConfidentialClient/OnBehalfOfProvider.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Graph.Auth
         /// Constructs a new <see cref="OnBehalfOfProvider"/>
         /// </summary>
         /// <param name="confidentialClientApplication">A <see cref="IConfidentialClientApplication"/> to pass to <see cref="OnBehalfOfProvider"/> for authentication.</param>
-        /// <param name="scopes">Scopes required to access Microsoft graph.</param>
+        /// <param name="scopes">Scopes required to access Microsoft Graph. This defaults to https://graph.microsoft.com/.default when none is set.</param>
         public OnBehalfOfProvider(
             IConfidentialClientApplication confidentialClientApplication,
-            string[] scopes)
+            string[] scopes = null)
             : base(scopes)
         {
             ClientApplication = confidentialClientApplication ?? throw new AuthenticationException(

--- a/src/Microsoft.Graph.Auth/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Auth/Exceptions/ErrorConstants.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Graph.Auth
     {
         internal static class Codes
         {
-            internal const string AuthenticationChallengeRequired = "authenticationChallengeRequired";
             internal const string TemporarilyUnavailable = "temporarily_unavailable";
+            internal const string AuthenticationChallengeRequired = "authenticationChallengeRequired";
             internal const string InvalidClaim = "invalidClaim";
             internal const string InvalidRequest = "invalidRequest";
             internal const string GeneralException = "generalException";
-            internal const string InvalidJWT = "InvalidJWT";
+            internal const string InvalidJWT = "invalidJWT";
         }
 
         internal static class Message
@@ -25,6 +25,7 @@ namespace Microsoft.Graph.Auth
             internal static string UnexpectedMsalException = "Unexpected exception returned from MSAL.";
             internal static string UnexpectedException = "Unexpected exception occured while authenticating the request.";
             internal const string InvalidJWT = "Invalid JWT access token.";
+            internal const string EmptyScopes = "Scopes cannot be empty.";
         }
     }
 }

--- a/src/Microsoft.Graph.Auth/MsalAuthenticationBase.cs
+++ b/src/Microsoft.Graph.Auth/MsalAuthenticationBase.cs
@@ -33,10 +33,15 @@ namespace Microsoft.Graph.Auth
         /// <summary>
         /// Constructs a new <see cref="MsalAuthenticationBase"/>
         /// </summary>
-        /// <param name="scopes">Scopes requested to access a protected API</param>
-        public MsalAuthenticationBase(string[] scopes)
+        /// <param name="graphScopes">Scopes requested to access a protected API</param>
+        public MsalAuthenticationBase(string[] graphScopes = null)
         {
-            Scopes = scopes;
+            Scopes = graphScopes ?? new string[] { AuthConstants.DefaultScopeUrl };
+
+            if (Scopes.Count() == 0)
+            {
+                throw new AuthenticationException(new Error { Code = ErrorConstants.Codes.InvalidRequest, Message = ErrorConstants.Message.EmptyScopes}, new ArgumentException());
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Auth/PublicClient/DeviceCodeProvider.cs
+++ b/src/Microsoft.Graph.Auth/PublicClient/DeviceCodeProvider.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Graph.Auth
         /// Constructs a new <see cref="DeviceCodeProvider"/>
         /// </summary>
         /// <param name="publicClientApplication">A <see cref="IPublicClientApplication"/> to pass to <see cref="DeviceCodeProvider"/> for authentication.</param>
-        /// <param name="scopes">Scopes required to access Microsoft graph.</param>
+        /// <param name="scopes">Scopes required to access Microsoft Graph. This defaults to https://graph.microsoft.com/.default when none is set.</param>
         /// <param name="deviceCodeResultCallback">Callback containing information to show the user about how to authenticate and enter the device code.</param>
         public DeviceCodeProvider(
             IPublicClientApplication publicClientApplication,
-            string[] scopes,
+            string[] scopes = null,
             Func<DeviceCodeResult, Task> deviceCodeResultCallback = null)
             : base(scopes)
         {

--- a/src/Microsoft.Graph.Auth/PublicClient/IntegratedWindowsAuthenticationProvider.cs
+++ b/src/Microsoft.Graph.Auth/PublicClient/IntegratedWindowsAuthenticationProvider.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Graph.Auth
         /// Constructs a new <see cref="IntegratedWindowsAuthenticationProvider"/>
         /// </summary>
         /// <param name="publicClientApplication">A <see cref="IPublicClientApplication"/> to pass to <see cref="DeviceCodeProvider"/> for authentication.</param>
-        /// <param name="scopes">Scopes required to access Microsoft graph.</param>
+        /// <param name="scopes">Scopes required to access Microsoft Graph. This defaults to https://graph.microsoft.com/.default when none is set.</param>
         public IntegratedWindowsAuthenticationProvider(
            IPublicClientApplication publicClientApplication,
-           string[] scopes)
+           string[] scopes = null)
            : base(scopes)
         {
             ClientApplication = publicClientApplication ?? throw new AuthenticationException(

--- a/src/Microsoft.Graph.Auth/PublicClient/InteractiveAuthenticationProvider.cs
+++ b/src/Microsoft.Graph.Auth/PublicClient/InteractiveAuthenticationProvider.cs
@@ -30,12 +30,12 @@ namespace Microsoft.Graph.Auth
         /// Constructs a new <see cref="InteractiveAuthenticationProvider"/>
         /// </summary>
         /// <param name="publicClientApplication">A <see cref="IPublicClientApplication"/> to pass to <see cref="DeviceCodeProvider"/> for authentication.</param>
-        /// <param name="scopes">Scopes required to access a protected API.</param>
+        /// <param name="scopes">Scopes required to access Microsoft Graph. This defaults to https://graph.microsoft.com/.default when none is set.</param>
         /// <param name="uiBehavior">Designed interactive experience for the user. Defaults to <see cref="UIBehavior.SelectAccount"/>.</param>
         /// <param name="uiParent">Object containing a reference to the parent window/activity. REQUIRED for Xamarin.Android only.</param>
         public InteractiveAuthenticationProvider(
             IPublicClientApplication publicClientApplication,
-            string[] scopes,
+            string[] scopes = null,
             UIBehavior? uiBehavior = null,
             UIParent uiParent = null)
             : base(scopes)

--- a/src/Microsoft.Graph.Auth/PublicClient/UsernamePasswordProvider.cs
+++ b/src/Microsoft.Graph.Auth/PublicClient/UsernamePasswordProvider.cs
@@ -22,10 +22,10 @@ namespace Microsoft.Graph.Auth
         /// We recommend you use <see cref="IntegratedWindowsAuthenticationProvider"/> instead.
         /// </summary>
         /// <param name="publicClientApplication">A <see cref="IPublicClientApplication"/> to pass to <see cref="DeviceCodeProvider"/> for authentication.</param>
-        /// <param name="scopes">Scopes required to access a protected API.</param>
+        /// <param name="scopes">Scopes required to access Microsoft Graph. This defaults to https://graph.microsoft.com/.default when none is set.</param>
         public UsernamePasswordProvider(
             IPublicClientApplication publicClientApplication,
-            string[] scopes)
+            string[] scopes = null)
             : base(scopes)
         {
             ClientApplication = publicClientApplication ?? throw new AuthenticationException(


### PR DESCRIPTION
## Fixes
- Issue #13 

## Changes
- Updates `ClientCredentialProvider` readme.
- Adds support for `https://graph.microsoft.com/.default` when scopes are null .
- Updates unit tests to reflect changes.

### Reference:
- https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#the-default-scope