### PR TITLE
OBO Provider Fixes

### DIFF
--- a/src/Microsoft.Graph.Auth.Test/ConfidentialClient/OnBehalfOfProviderTests.cs
+++ b/src/Microsoft.Graph.Auth.Test/ConfidentialClient/OnBehalfOfProviderTests.cs
@@ -34,7 +34,6 @@
                 TenantId = Guid.NewGuid().ToString()
             };
             _silentAuthResult = MockAuthResult.GetAuthenticationResult(new GraphAccount(_graphUserAccount), _scopes);
-            
             _mockClientApplicationBase = new MockConfidentialClientApplication(_scopes, "common", false, _clientId, _silentAuthResult);
         }
 
@@ -159,6 +158,18 @@
             Assert.IsInstanceOfType(authProvider.ClientApplication, typeof(IConfidentialClientApplication), "Unexpected client application set.");
             Assert.IsNotNull(httpRequestMessage.Headers.Authorization, "Unexpected auhtorization header set.");
             Assert.AreEqual(_silentAuthResult.AccessToken, httpRequestMessage.Headers.Authorization.Parameter, "Unexpected access token set.");
+        }
+
+        [TestMethod]
+        public void OnBehalfOfProvider_ShouldGetGraphUserAccountFromJwtString()
+        {
+            OnBehalfOfProvider authProvider = new OnBehalfOfProvider(_mockClientApplicationBase.Object, _scopes);
+            GraphUserAccount userAccount = authProvider.GetGraphUserAccountFromJwt(_jwtAccessToken);
+
+            Assert.IsNotNull(userAccount, "Unexpected graph user account.");
+            Assert.AreEqual(userAccount.ObjectId, "e602ada7-6efd-4e18-a979-63c02b9f3c76", "Unexpected oid set.");
+            Assert.AreEqual(userAccount.TenantId, "6bc15335-e2b8-4a9a-8683-a52a26c8c583", "Unexpected tid set.");
+            Assert.AreEqual(userAccount.Email, "john@doe.test.com", "Unexpected email set.");
         }
     }
 }

--- a/src/Microsoft.Graph.Auth/ConfidentialClient/OnBehalfOfProvider.cs
+++ b/src/Microsoft.Graph.Auth/ConfidentialClient/OnBehalfOfProvider.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Graph.Auth
             {
                 Email = jwtPayload.Upn,
                 ObjectId = jwtPayload.Oid.ToString(),
-                TenantId = jwtPayload.Oid.ToString()
+                TenantId = jwtPayload.Tid.ToString()
             };
         }
     }

--- a/src/Microsoft.Graph.Auth/MsalAuthenticationBase.cs
+++ b/src/Microsoft.Graph.Auth/MsalAuthenticationBase.cs
@@ -74,19 +74,9 @@ namespace Microsoft.Graph.Auth
                     ClientApplication.Authority,
                     msalAuthProviderOption.ForceRefresh);
             }
-            catch (MsalUiRequiredException msalUiEx)
+            catch (MsalException msalEx)
             {
                 return null;
-            }
-            catch (MsalServiceException serviceException)
-            {
-                throw new AuthenticationException(
-                        new Error
-                        {
-                            Code = ErrorConstants.Codes.GeneralException,
-                            Message = ErrorConstants.Message.UnexpectedMsalException
-                        },
-                        serviceException);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
This PR fixes the following open issues with the On Behalf Of Provider:
- Issue #29. `MsalException` with error code `user_mismatch` was being thrown when an app switches from one user to another. This PR updates the code to get a new token when an `MsalException` is throw when acquiring a token silently.

- Issue #28. The tenant id field from the jwt payload was being ignored when using `.WithUserAssertion` extension method. This PR extracts this field and adds it to a `GraphUserAccount` object.