### PR TITLE
Update increment script

### DIFF
--- a/scripts/IncrementPreviewVersion.ps1
+++ b/scripts/IncrementPreviewVersion.ps1
@@ -27,7 +27,7 @@ $xmlDoc = New-Object System.Xml.XmlDocument
 $xmlDoc.Load($projectPath)
 
 # Assumption: VersionSuffix is set in the first property group.
-$versionSuffixString = $xmlDoc.Project.PropertyGroup[0].VersionSuffix
+$versionSuffixString = $xmlDoc.Project.PropertyGroup.VersionSuffix
 
 # Don't do anything if a VersionSuffix has been set in the .csproj.
 if ($versionSuffixString -ne '' -and $versionSuffixString -ne $null) {
@@ -41,7 +41,7 @@ if ($versionSuffixString -ne '' -and $versionSuffixString -ne $null) {
 if ($versionSuffixString -eq $null) {
     Write-Host "The VersionSuffix element had been deleted from the csproj. Adding it back."
     $newVersionSuffixElement = $xmlDoc.CreateElement("VersionSuffix")
-    $newElement = $xmlDoc.Project.PropertyGroup[0].AppendChild($newVersionSuffixElement)
+    $newElement = $xmlDoc.Project.PropertyGroup.AppendChild($newVersionSuffixElement)
 }
 
 # API is case-sensitive
@@ -74,5 +74,5 @@ else {
 
 Write-Host "The preview version is now $versionSuffixString" -ForegroundColor Green
 
-$xmlDoc.Project.PropertyGroup[0].VersionSuffix = $versionSuffixString
+$xmlDoc.Project.PropertyGroup.VersionSuffix = $versionSuffixString
 $xmlDoc.Save($projectPath)

--- a/scripts/IncrementPreviewVersion.ps1
+++ b/scripts/IncrementPreviewVersion.ps1
@@ -26,7 +26,7 @@ Param(
 $xmlDoc = New-Object System.Xml.XmlDocument
 $xmlDoc.Load($projectPath)
 
-# Assumption: VersionSuffix is set in the first property group.
+# Assumption: VersionSuffix is set in the ONLY property group.
 $versionSuffixString = $xmlDoc.Project.PropertyGroup.VersionSuffix
 
 # Don't do anything if a VersionSuffix has been set in the .csproj.


### PR DESCRIPTION
Querying an element that can occur one or more times is a bit
inconsistent. For example, if there is an xml document
`<H1><H2/><H2/></H1>`, the first element is queried by $xmldoc.H1.H2[0].
If there is a single element, `<H1><H2/></H1>`, $xmldoc.H1.H2[0] is
no longer valid. The valid query is now $xmldoc.H1.H2