### PR TITLE
Update MSAL dependency to v4.3.1

### DIFF
--- a/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
+++ b/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
@@ -27,8 +27,8 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Core" Version="1.*" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.3.1" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/tests/Microsoft.Graph.Auth.Test/Microsoft.Graph.Auth.Test.csproj
+++ b/tests/Microsoft.Graph.Auth.Test/Microsoft.Graph.Auth.Test.csproj
@@ -5,8 +5,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Core" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="Moq" Version="4.11.0-rc1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Resolves #49 (and should add better .NET Core and Xamarin iOS support due to [MSAL updates](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/releases))
Also, correlate dependencies for tests to function as called out in #18

Tests still seem to pass, so I didn't see any breaking changes.

I'm trying to build a local NuGet to test in my .NET Core project which requires this update.