### PR TITLE
Acquire Token Silent WithAuthority Fix

### DIFF
--- a/src/Microsoft.Graph.Auth/Extensions/IClientApplicationBaseExtensions.cs
+++ b/src/Microsoft.Graph.Auth/Extensions/IClientApplicationBaseExtensions.cs
@@ -41,10 +41,13 @@ namespace Microsoft.Graph.Auth.Extensions
 
             try
             {
-                return await clientApplication.AcquireTokenSilent(msalAuthProviderOption.Scopes, account)
-                        .WithAuthority(clientApplication.Authority)
-                        .WithForceRefresh(msalAuthProviderOption.ForceRefresh)
-                        .ExecuteAsync();
+                AcquireTokenSilentParameterBuilder tokenSilentBuilder = clientApplication.AcquireTokenSilent(msalAuthProviderOption.Scopes, account)
+                    .WithForceRefresh(msalAuthProviderOption.ForceRefresh);
+
+                if (IsSkipAuthority(clientApplication.Authority))
+                    tokenSilentBuilder.WithAuthority(clientApplication.Authority);
+
+                return await tokenSilentBuilder.ExecuteAsync();
             }
             catch (MsalException)
             {
@@ -60,6 +63,13 @@ namespace Microsoft.Graph.Auth.Extensions
                         },
                         exception);
             }
+        }
+
+        private static bool IsSkipAuthority(string currentAuthority)
+        {
+            return !(currentAuthority.Contains($"\\{AuthConstants.Tenants.Common}")
+                || currentAuthority.Contains($"\\{AuthConstants.Tenants.Consumers}")
+                || currentAuthority.Contains($"\\{AuthConstants.Tenants.Organizations}"));
         }
     }
 }

--- a/src/Microsoft.Graph.Auth/Extensions/IClientApplicationBaseExtensions.cs
+++ b/src/Microsoft.Graph.Auth/Extensions/IClientApplicationBaseExtensions.cs
@@ -15,11 +15,16 @@ namespace Microsoft.Graph.Auth.Extensions
     /// </summary>
     public static class IClientApplicationBaseExtensions
     {
-        /// <summary>
-        /// Attempts to acquire access token silently from the token cache.
-        /// </summary>
-        /// <exception cref="AuthenticationException">An exception occured when attempting to get access token silently.</exception>
-        internal static async Task<AuthenticationResult> GetAccessTokenSilentAsync(this IClientApplicationBase clientApplication, AuthenticationProviderOption msalAuthProviderOption)
+        private static List<string> WellKnownTenants = new List<string>
+            {   AuthConstants.Tenants.Common,
+                AuthConstants.Tenants.Consumers,
+                AuthConstants.Tenants.Organizations
+            };
+    /// <summary>
+    /// Attempts to acquire access token silently from the token cache.
+    /// </summary>
+    /// <exception cref="AuthenticationException">An exception occured when attempting to get access token silently.</exception>
+    internal static async Task<AuthenticationResult> GetAccessTokenSilentAsync(this IClientApplicationBase clientApplication, AuthenticationProviderOption msalAuthProviderOption)
         {
             IAccount account;
             if (msalAuthProviderOption.UserAccount?.ObjectId != null)
@@ -44,7 +49,7 @@ namespace Microsoft.Graph.Auth.Extensions
                 AcquireTokenSilentParameterBuilder tokenSilentBuilder = clientApplication.AcquireTokenSilent(msalAuthProviderOption.Scopes, account)
                     .WithForceRefresh(msalAuthProviderOption.ForceRefresh);
 
-                if (ContainsWellKnownTenantName(clientApplication.Authority))
+                if (!ContainsWellKnownTenantName(clientApplication.Authority))
                     tokenSilentBuilder.WithAuthority(clientApplication.Authority);
 
                 return await tokenSilentBuilder.ExecuteAsync();
@@ -77,11 +82,7 @@ namespace Microsoft.Graph.Auth.Extensions
 
             Uri authorityUri = new Uri(currentAuthority);
 
-            return (new List<string>
-            {   AuthConstants.Tenants.Common,
-                AuthConstants.Tenants.Consumers,
-                AuthConstants.Tenants.Organizations
-            }).Contains(authorityUri.Segments[1].Replace(@"/", string.Empty));
+            return WellKnownTenants.Contains(authorityUri.Segments[1].Replace(@"/", string.Empty));
         }
     }
 }

--- a/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
+++ b/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
@@ -27,8 +27,8 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Core" Version="1.17.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.5.1" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
+++ b/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
@@ -23,7 +23,7 @@
     <DelaySign>true</DelaySign>
     <!--Skip 1.13.0-->
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>preview.2</VersionSuffix>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Microsoft.Graph.Auth.Test/Extensions/IClientApplicationBaseExtensionsTests.cs
+++ b/tests/Microsoft.Graph.Auth.Test/Extensions/IClientApplicationBaseExtensionsTests.cs
@@ -1,0 +1,47 @@
+﻿namespace Microsoft.Graph.Auth.Test.Extensions
+{
+    using Microsoft.Graph.Auth.Extensions;
+    using Microsoft.Identity.Client;
+    using System;
+    using System.Collections.Generic;
+    using Xunit;
+    public class IClientApplicationBaseExtensionsTests
+    {
+        [Fact]
+        public void ShouldSkipSettingAuthorityWhenWellKnownAuthoritiesAreSet()
+        {
+            string commonAuthority = AuthorityExtensions.GetAuthorityUrl(AzureCloudInstance.AzurePublic, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount);
+            string multiOrgAuthority = AuthorityExtensions.GetAuthorityUrl(AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdMultipleOrgs);
+            string msaAuthority = AuthorityExtensions.GetAuthorityUrl(AzureCloudInstance.AzureGermany, AadAuthorityAudience.PersonalMicrosoftAccount);
+
+            string clientId = "00000000-0000-0000-0000-000000000000";
+
+            IPublicClientApplication publicClientApplication = PublicClientApplicationBuilder
+                .Create(clientId)
+                .WithAuthority(multiOrgAuthority)
+                .Build();
+
+            Assert.True(IClientApplicationBaseExtensions.ContainsWellKnownTenantName(commonAuthority));
+            Assert.True(IClientApplicationBaseExtensions.ContainsWellKnownTenantName(msaAuthority));
+            Assert.True(IClientApplicationBaseExtensions.ContainsWellKnownTenantName(publicClientApplication.Authority));
+        }
+
+        [Fact]
+        public void ShouldNotSkipSettingWhenCustomersTenantIsSet()
+        {
+            string tenantNameAuthority = AuthorityExtensions.GetAuthorityUrl(AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdMyOrg, "commonOrg");
+            string tenantGuidAuthority = AuthorityExtensions.GetAuthorityUrl(AzureCloudInstance.AzurePublic, AadAuthorityAudience.AzureAdMyOrg, Guid.NewGuid().ToString());
+
+            string randomGuid = "00000000-0000-0000-0000-000000000000";
+
+            IPublicClientApplication publicClientApplication = PublicClientApplicationBuilder
+                .Create(randomGuid)
+                .WithTenantId(randomGuid)
+                .Build();
+
+            Assert.False(IClientApplicationBaseExtensions.ContainsWellKnownTenantName(tenantNameAuthority));
+            Assert.False(IClientApplicationBaseExtensions.ContainsWellKnownTenantName(tenantGuidAuthority));
+            Assert.False(IClientApplicationBaseExtensions.ContainsWellKnownTenantName(publicClientApplication.Authority));
+        }
+    }
+}

--- a/tests/Microsoft.Graph.Auth.Test/Microsoft.Graph.Auth.Test.csproj
+++ b/tests/Microsoft.Graph.Auth.Test/Microsoft.Graph.Auth.Test.csproj
@@ -5,10 +5,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Core" Version="1.*" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="Moq" Version="4.11.0-rc1" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR is a mitigation to https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1456. It skips setting of an authority url to MSAL's `.AcquireTokenSilentParameterBuilder` when the authority url segment contains one of the following: common, consumers, and organizations.