### PR TITLE
Update dependency references to always use latest of major versions

### DIFF
--- a/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
+++ b/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
@@ -3,7 +3,6 @@
     <Description>Microsoft Graph Authentication Library implements authentication functionality used by Microsoft Graph Client Library. It provides a set of OAuth scenario-centric providers that implement Microsoft.Graph.IAuthenticationProvider and uses Microsoft Authentication Library (MSAL) to handle access token acquisition and storage.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph Auth Library</AssemblyTitle>
-    <AssemblyVersion>0.1.0</AssemblyVersion>
     <Authors>Microsoft</Authors>
     <Company>Microsoft Corporation</Company>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
@@ -23,7 +22,7 @@
     <DelaySign>true</DelaySign>
     <!--Skip 1.13.0-->
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.2</VersionSuffix>
+    <VersionSuffix>preview.3</VersionSuffix>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
+++ b/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
@@ -27,8 +27,8 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Core" Version="1.18.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="1.*" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.*" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/tests/Microsoft.Graph.Auth.Test/Microsoft.Graph.Auth.Test.csproj
+++ b/tests/Microsoft.Graph.Auth.Test/Microsoft.Graph.Auth.Test.csproj
@@ -5,8 +5,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph.Core" Version="1.18.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
This PR updates Microsoft.Graph.Auth package references to always use the latest versions of current major versions.
The affected packages are : 
```
<PackageReference Include="Microsoft.Graph.Core" Version="1.*" />
<PackageReference Include="Microsoft.Identity.Client" Version="4.*" />
```

This should make it easy for clients and applications that depend on this library to update Microsoft.Graph.Core and Microsoft.Identity.Client to the latest versions without waiting on us to update this library.

This also fixes "Could not load file or assembly" issue with MS Graph PowerShell SDK on Windows PowerShell when a referenced dependency package is of a greater version than what **Microsoft.Graph.Auth** uses.

Unblocks https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/67#issuecomment-576927434