### PR TITLE
Target netcore3.1 in test project

### DIFF
--- a/tests/Microsoft.Graph.Auth.Test/Microsoft.Graph.Auth.Test.csproj
+++ b/tests/Microsoft.Graph.Auth.Test/Microsoft.Graph.Auth.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR closes #74 by updating the target framework to .NET core 3.1. NET core 2.2 and 3.0 and in End of Line (EOL).