### PR TITLE
Add Continuous Access Evaluation (CAE) support

### DIFF
--- a/src/Microsoft.Graph.Auth/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.Graph.Auth/Extensions/HttpRequestMessageExtensions.cs
@@ -11,8 +11,16 @@ namespace Microsoft.Graph.Auth
         internal static AuthenticationProviderOption GetMsalAuthProviderOption(this HttpRequestMessage httpRequestMessage)
         {
             AuthenticationHandlerOption authHandlerOption = httpRequestMessage.GetMiddlewareOption<AuthenticationHandlerOption>();
+            AuthenticationProviderOption authenticationProviderOption = authHandlerOption?.AuthenticationProviderOption as AuthenticationProviderOption ?? new AuthenticationProviderOption();
 
-            return authHandlerOption?.AuthenticationProviderOption as AuthenticationProviderOption ?? new AuthenticationProviderOption();
+            // copy the claims and scopes information
+            if (authHandlerOption?.AuthenticationProviderOption is ICaeAuthenticationProviderOption caeAuthenticationProviderOption)
+            {
+                authenticationProviderOption.Claims = caeAuthenticationProviderOption.Claims;
+                authenticationProviderOption.Scopes = caeAuthenticationProviderOption.Scopes;
+            }
+
+            return authenticationProviderOption;
         }
     }
 }

--- a/src/Microsoft.Graph.Auth/Extensions/IClientApplicationBaseExtensions.cs
+++ b/src/Microsoft.Graph.Auth/Extensions/IClientApplicationBaseExtensions.cs
@@ -52,6 +52,9 @@ namespace Microsoft.Graph.Auth.Extensions
                 if (!ContainsWellKnownTenantName(clientApplication.Authority))
                     tokenSilentBuilder.WithAuthority(clientApplication.Authority);
 
+                if (!string.IsNullOrEmpty(msalAuthProviderOption.Claims))
+                    tokenSilentBuilder.WithClaims(msalAuthProviderOption.Claims);
+
                 return await tokenSilentBuilder.ExecuteAsync();
             }
             catch (MsalException)

--- a/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
+++ b/src/Microsoft.Graph.Auth/Microsoft.Graph.Auth.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Microsoft Graph Authentication Library implements authentication functionality used by Microsoft Graph Client Library. It provides a set of OAuth scenario-centric providers that implement Microsoft.Graph.IAuthenticationProvider and uses Microsoft Authentication Library (MSAL) to handle access token acquisition and storage.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
@@ -10,7 +10,7 @@
     <PackageId>Microsoft.Graph.Auth</PackageId>
     <PackageTags>Microsoft Office365;Graph;GraphServiceClient;Outlook;OneDrive;AzureAD;GraphAPI;Productivity;SharePoint;Intune;SDK;MSAL</PackageTags>
     <PackageReleaseNotes>
-      - Updates licensing agreement
+- Adds support for Continuous Access Evaluation scenarios to Interactive and DeviceCode providers
     </PackageReleaseNotes>
     <PackageProjectUrl>https://developer.microsoft.com/graph</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
@@ -20,7 +20,7 @@
     <DelaySign>true</DelaySign>
     <!--Skip 1.13.0-->
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.5</VersionSuffix>
+    <VersionSuffix>preview.6</VersionSuffix>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Graph.Auth/MsalAuthenticationProviderOption.cs
+++ b/src/Microsoft.Graph.Auth/MsalAuthenticationProviderOption.cs
@@ -41,5 +41,10 @@ namespace Microsoft.Graph.Auth
         /// Password to use when authenticating with UsernamePasswordProvider.
         /// </summary>
         public SecureString Password { get; set; }
+
+        /// <summary>
+        /// Claims for a given request
+        /// </summary>
+        public string Claims { get; set; }
     }
 }

--- a/src/Microsoft.Graph.Auth/PublicClient/DeviceCodeProvider.cs
+++ b/src/Microsoft.Graph.Auth/PublicClient/DeviceCodeProvider.cs
@@ -88,12 +88,19 @@ namespace Microsoft.Graph.Auth
             int retryCount = 0;
             string extraQueryParameter = null;
             do
-            {
+            {   
                 try
                 {
-                    authenticationResult = await ClientApplication.AcquireTokenWithDeviceCode(msalAuthProviderOption.Scopes, DeviceCodeResultCallback)
-                        .WithExtraQueryParameters(extraQueryParameter)
-                        .ExecuteAsync(cancellationToken);
+                    AcquireTokenWithDeviceCodeParameterBuilder parameterBuilder = ClientApplication
+                        .AcquireTokenWithDeviceCode(msalAuthProviderOption.Scopes, DeviceCodeResultCallback)
+                        .WithExtraQueryParameters(extraQueryParameter);
+
+                    if (!string.IsNullOrEmpty(msalAuthProviderOption.Claims))
+                    {
+                        parameterBuilder.WithClaims(msalAuthProviderOption.Claims);
+                    }
+
+                    authenticationResult = await parameterBuilder.ExecuteAsync(cancellationToken);
                     break;
                 }
                 catch (MsalServiceException serviceException)

--- a/src/Microsoft.Graph.Auth/PublicClient/InteractiveAuthenticationProvider.cs
+++ b/src/Microsoft.Graph.Auth/PublicClient/InteractiveAuthenticationProvider.cs
@@ -149,6 +149,11 @@ namespace Microsoft.Graph.Auth
                         .WithExtraQueryParameters(extraQueryParameter)
                         .WithExtraScopesToConsent(null)
                         .WithAuthority(ClientApplication.Authority);
+
+                    if (!string.IsNullOrEmpty(msalAuthProviderOption.Claims))
+                    {
+                        builder.WithClaims(msalAuthProviderOption.Claims);
+                    }
 #if NET45
                     if (ParentWindow != null)
                     {

--- a/tests/Microsoft.Graph.Auth.Test/Extensions/HttpRequestMessageExtensionsTests.cs
+++ b/tests/Microsoft.Graph.Auth.Test/Extensions/HttpRequestMessageExtensionsTests.cs
@@ -1,0 +1,42 @@
+﻿namespace Microsoft.Graph.Auth.Test.Extensions
+{
+    using System.Net.Http;
+    using Xunit;
+
+    public class HttpRequestMessageExtensionsTests
+    {
+        [Fact]
+        public void CanExtractClaimsFromICaeAuthenticationProviderOption()
+        {
+            // Arrange
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com/bar");
+            var authenticationHandlerOption = new AuthenticationHandlerOption();
+            var authenticationProviderOption = new CaeAuthProviderOptionTest()
+            {
+                Scopes = new [] { "User.Read" },
+                Claims = "claim"
+            };
+            authenticationHandlerOption.AuthenticationProviderOption = authenticationProviderOption;
+
+            // set the original AuthenticationProviderOptionTest as the auth provider
+            var originalRequestContext = httpRequestMessage.GetRequestContext();
+            originalRequestContext.MiddlewareOptions[typeof(AuthenticationHandlerOption).ToString()] = authenticationHandlerOption;
+            httpRequestMessage.Properties[typeof(GraphRequestContext).ToString()] = originalRequestContext;
+
+            // Act by trying to extract info from ICaeAuthenticationProviderOption type
+            AuthenticationProviderOption authProviderOption = httpRequestMessage.GetMsalAuthProviderOption();
+
+            // Assert that we can still find the information
+            Assert.Single(authProviderOption.Scopes);
+            Assert.Equal("User.Read", authProviderOption.Scopes[0]);
+            Assert.Equal("claim", authProviderOption.Claims);
+
+        }
+    }
+
+    internal class CaeAuthProviderOptionTest : ICaeAuthenticationProviderOption
+    {
+        public string[] Scopes { get; set; }
+        public string Claims { get; set; }
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/166

The PR is dependent on the merge and release of changes in [this PR](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth/pull/91).

It involves the reading and using of the Claims Property from `GraphContext` through the new `ICaeAuthenticationProviderOption` interface and using it to call the relevant MSAL builders for the Interactive and DeviceCode providers